### PR TITLE
feat: Add user auth API and schemas

### DIFF
--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from app.schemas.user import UserSignup, UserLogin
+from app.db.session import get_db
+from app.crud import user_crud
+
+router = APIRouter()
+
+@router.post("/signup")
+def signup(user: UserSignup, db: Session = Depends(get_db)):
+    try:
+        db_user = user_crud.create_user(db, user)
+        return {"status": "success", "user_id": db_user.id}
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Nickname already exists")
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+
+@router.post("/login")
+def login(user: UserLogin, db: Session = Depends(get_db)):
+    db_user = user_crud.authenticate_user(db, user.nickname, user.password)
+    if not db_user:
+        raise HTTPException(status_code=400, detail="Invalid nickname or password")
+    return {"status": "success", "user_id": db_user.id}

--- a/app/api/v1/endpoints/survey.py
+++ b/app/api/v1/endpoints/survey.py
@@ -8,7 +8,7 @@ from gemini_api.gemini_api_client import generate_travel_recommendation
 
 router = APIRouter()
 
-@router.post("/survey/recommend", summary="설문 작성 및 AI 추천 결과 반환")
+@router.post("/recommend", summary="설문 작성 및 AI 추천 결과 반환")
 def survey_and_recommend(survey: SurveyCreate, db: Session = Depends(get_db)):
     # 1. 설문 저장
     saved_survey = survey_crud.create_survey(db=db, survey=survey)

--- a/app/crud/survey_crud.py
+++ b/app/crud/survey_crud.py
@@ -1,4 +1,3 @@
-# app/crud/survey_crud.py
 # 설문 저장 로직
 
 from sqlalchemy.orm import Session

--- a/app/crud/user_crud.py
+++ b/app/crud/user_crud.py
@@ -1,0 +1,20 @@
+from sqlalchemy.orm import Session
+from app.models.user import User
+from app.schemas.user import UserSignup
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def create_user(db: Session, user: UserSignup):
+    hashed_pw = pwd_context.hash(user.password)
+    db_user = User(name=user.name, nickname=user.nickname, hashed_password=hashed_pw)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+def authenticate_user(db: Session, nickname: str, password: str):
+    db_user = db.query(User).filter(User.nickname == nickname).first()
+    if not db_user or not pwd_context.verify(password, db_user.hashed_password):
+        return None
+    return db_user

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,4 +1,3 @@
-# app/db/base.py
 # # SQLAlchemy Base
 
 from sqlalchemy.ext.declarative import declarative_base

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,21 +1,26 @@
-# app/db/session.py
 # DB 연결
 
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-
 from dotenv import load_dotenv
+
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+# ✅ 환경변수 우선순위: SQLALCHEMY_DATABASE_URL > DATABASE_URL
+SQLALCHEMY_DATABASE_URL = (
+    os.getenv("SQLALCHEMY_DATABASE_URL")
+    or os.getenv("DATABASE_URL")
+)
 
-if DATABASE_URL is None:
-    raise ValueError("DATABASE_URL is not set in the environment variables.")
+if not SQLALCHEMY_DATABASE_URL:
+    raise ValueError("❌ DB 연결 문자열이 환경변수에 없습니다 (.env에 SQLALCHEMY_DATABASE_URL 또는 DATABASE_URL 필요)")
 
-engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+# ✅ DB 연결 및 세션 설정
+engine = create_engine(SQLALCHEMY_DATABASE_URL, pool_pre_ping=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+# ✅ FastAPI 의존성 주입용
 def get_db():
     db = SessionLocal()
     try:

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.api.v1.endpoints import survey
+from app.api.v1.endpoints import survey, auth  # ✅ auth 라우터 import
 from app.db.init_db import init_db
 
 app = FastAPI(title="Travia API", version="1.0")
@@ -15,5 +15,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# 라우터 연결
-app.include_router(survey.router, prefix="/api/v1")
+# ✅ 라우터 연결
+app.include_router(survey.router, prefix="/api/v1/survey")  # 기존 설문 라우터
+app.include_router(auth.router, prefix="/api/auth")         # 신규 auth 라우터 추가

--- a/app/models/survey.py
+++ b/app/models/survey.py
@@ -1,4 +1,3 @@
-# app/models/survey.py
 # 설문 테이블 모델
 
 from sqlalchemy import Column, Integer, String, JSON, TIMESTAMP, func

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+from app.db.base import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False)
+    nickname = Column(String(100), unique=True, nullable=False)
+    hashed_password = Column(String(200), nullable=False)

--- a/app/schemas/survey.py
+++ b/app/schemas/survey.py
@@ -1,11 +1,11 @@
-# app/schemas/survey.py
 # Pydantic 요청 스키마
 
 from pydantic import BaseModel
+from typing import List
 
 class Preferences(BaseModel):
     companion: str
-    style: str
+    style: List[str]
     duration: str
     driving: str
     budget: str

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+class UserSignup(BaseModel):
+    name: str
+    nickname: str
+    password: str
+
+class UserLogin(BaseModel):
+    nickname: str
+    password: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 httpx
 cryptography
 google.generativeai
+passlib[bcrypt]


### PR DESCRIPTION
### 변경 내용
- 사용자 인증 관련 API 추가 (`auth.py`)
- `user_crud`, `user`, `schemas.user` 등 사용자 관련 파일 생성
- 기존 survey 모델과의 연결은 아직 X

### 테스트
- 로컬에서 `uvicorn` 실행 후 `/auth` 경로 테스트 완료

### 확인 요청
- 파일 구조 및 API 설계 방향 검토 부탁드립니다.
